### PR TITLE
add make and unit test into ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: go
 go_import_path: github.com/opensds/nbp
 
 go:
-  - 1.8.x
+  - 1.9.x
   - tip
 
 env:
@@ -29,3 +29,10 @@ matrix:
     env: TARGET=386
   - go: tip
     env: TARGET=ppc64le
+
+install:
+  - make
+
+script:
+  - go test -v github.com/opensds/nbp/csi/... -cover
+


### PR DESCRIPTION
add make and unit test into ci.
in addition to upgrade go 1.9,
since the lastest kubernetes require 1.9.