### PR TITLE
Update kubernetes deploy script of CSI plugin

### DIFF
--- a/csi/server/deploy/kubernetes/csi-nodeplugin-opensdsplugin.yaml
+++ b/csi/server/deploy/kubernetes/csi-nodeplugin-opensdsplugin.yaml
@@ -24,14 +24,14 @@ spec:
             - "--csi-address=$(ADDRESS)"
           env:
             - name: ADDRESS
-              value: /csi/csi.sock
+              value: /var/lib/kubelet/plugins/csi-opensdsplugin/csi.sock
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
           volumeMounts:
             - name: socket-dir
-              mountPath: /csi
+              mountPath: /var/lib/kubelet/plugins/csi-opensdsplugin
         - name: opensds
           securityContext:
             privileged: true
@@ -44,7 +44,7 @@ spec:
             - "--opensdsEndpoint=$(OPENSDS_ENDPOINT)"
           env:
             - name: CSI_ENDPOINT
-              value: unix://csi/csi.sock
+              value: unix://var/lib/kubelet/plugins/csi-opensdsplugin/csi.sock
             - name: OPENSDS_ENDPOINT
               valueFrom:
                 configMapKeyRef:
@@ -53,7 +53,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
-              mountPath: /csi
+              mountPath: /var/lib/kubelet/plugins/csi-opensdsplugin
             - name: pods-mount-dir
               mountPath: /var/lib/kubelet/pods
               mountPropagation: "Bidirectional"
@@ -67,7 +67,7 @@ spec:
       volumes:
         - name: socket-dir
           hostPath:
-            path: /csi
+            path: /var/lib/kubelet/plugins/csi-opensdsplugin
             type: DirectoryOrCreate		
         - name: pods-mount-dir
           hostPath:

--- a/csi/server/plugin/opensds/controller.go
+++ b/csi/server/plugin/opensds/controller.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi/v0"
-	"github.com/opensds/nbp/client/iscsi"
 	sdscontroller "github.com/opensds/nbp/client/opensds"
 	"github.com/opensds/opensds/pkg/model"
 	"golang.org/x/net/context"
@@ -163,7 +162,6 @@ func (p *Plugin) ControllerPublishVolume(
 			Host:      req.NodeId,
 			Platform:  runtime.GOARCH,
 			OsType:    runtime.GOOS,
-			Ip:        iscsi.GetHostIp(),
 			Initiator: localIqn,
 		},
 		Metadata: req.VolumeAttributes,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

In kubernetes, the kubelet daemon will use the `/var/lib/kubelet/plugins/nodeplugin-name/csi.sock` as the csi address. So the csi address was corrected in the deploy scripts of csi-oensdsplugin.

