### PR TITLE
Set ubuntu image tag to xenial

### DIFF
--- a/csi/server/Dockerfile
+++ b/csi/server/Dockerfile
@@ -1,5 +1,5 @@
 # Based on ubuntu
-FROM ubuntu
+FROM ubuntu:xenial
 LABEL maintainers="Edison Xiang <xiang.edison@gmail.com>"
 LABEL description="OpenSDS CSI Plugin"
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The CSI plugin has been tested successfully based on ubuntu 16.04 (xenial), but the default ubuntu image with latest tag has changed from `xenial ` to `bionic` recently, therefore the image tag of ubuntu should be specified as `xenial` to avoid software version incompatibility caused by operating system version. 

**Which issue this PR fixes** : fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
