### PR TITLE
Reduce number of CI jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,24 +11,11 @@ go:
 env:
   matrix:
    - TARGET=amd64
-   - TARGET=arm64
-   - TARGET=arm
-   - TARGET=386
-   - TARGET=ppc64le
 
 matrix:
   fast_finish: true
   allow_failures:
     - go: tip
-  exclude:
-  - go: tip
-    env: TARGET=arm
-  - go: tip
-    env: TARGET=arm64
-  - go: tip
-    env: TARGET=386
-  - go: tip
-    env: TARGET=ppc64le
 
 install:
   - make


### PR DESCRIPTION
**What this PR does / why we need it**:

For now we want to limit the number of Travis CI jobs that
are run to just the amd64 platform. This removes other
platform targets until we are ready to expand this.
