### PR TITLE
fixed a wrong calculation about volumeinfo

### DIFF
--- a/csi/server/plugin/opensds/controller.go
+++ b/csi/server/plugin/opensds/controller.go
@@ -48,9 +48,9 @@ func (p *Plugin) CreateVolume(
 	// build volume body
 	volumebody := &model.VolumeSpec{}
 	volumebody.Name = req.Name
+	allocationUnitBytes := int64(1024 * 1024 * 1024)
 	if req.CapacityRange != nil {
 		volumeSizeBytes := int64(req.CapacityRange.RequiredBytes)
-		allocationUnitBytes := int64(1024 * 1024 * 1024)
 		volumebody.Size = (volumeSizeBytes + allocationUnitBytes - 1) / allocationUnitBytes
 		if volumebody.Size < 1 {
 			//Using default volume size
@@ -87,7 +87,7 @@ func (p *Plugin) CreateVolume(
 
 	// return volume info
 	volumeinfo := &csi.Volume{
-		CapacityBytes: v.Size,
+		CapacityBytes: v.Size * allocationUnitBytes,
 		Id:            v.Id,
 		Attributes: map[string]string{
 			KVolumeName:      v.Name,


### PR DESCRIPTION
rebase by development branch

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The value of 'CapacityRangeBytes' of volumeinfo is in bytes , but the 'v.size' is in Gigabytes.
my mistake, last pr is base on master branch , leading to unuseful commit records.Sorry for that.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
