### PR TITLE
resolve container restart mount error

### DIFF
--- a/csi/server/deploy/kubernetes/csi-nodeplugin-opensdsplugin.yaml
+++ b/csi/server/deploy/kubernetes/csi-nodeplugin-opensdsplugin.yaml
@@ -59,7 +59,7 @@ spec:
               mountPropagation: "Bidirectional"
             - name: pods-probe-dir
               mountPath: /dev
-              mountPropagation: "Bidirectional"
+              mountPropagation: "HostToContainer"
             - name: iscsi-dir
               mountPath: /etc/iscsi/
             - name: ceph-dir


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Container mount error is reported every time the container is restarted.
**Which issue this PR fixes** :
 fixes #86

**Special notes for your reviewer**:
Please test this change again.
