### PR TITLE
Implement NodeGetInfo

### DIFF
--- a/csi/server/plugin/opensds/node.go
+++ b/csi/server/plugin/opensds/node.go
@@ -281,12 +281,25 @@ func (p *Plugin) NodeGetId(
 	}, nil
 }
 
-// NodeGetInfo
+// NodeGetInfo gets information on a node
 func (p *Plugin) NodeGetInfo(
 	ctx context.Context,
 	req *csi.NodeGetInfoRequest) (
 	*csi.NodeGetInfoResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "")
+	glog.Info("start to GetNodeInfo")
+	defer glog.Info("end to GetNodeInfo")
+
+	// TODO: For non-iscsi protocol, iqn should not be
+	// used as NodeId here.
+	iqns, _ := iscsi.GetInitiator()
+	localIqn := ""
+	if len(iqns) > 0 {
+		localIqn = iqns[0]
+	}
+
+	return &csi.NodeGetInfoResponse{
+		NodeId: localIqn,
+	}, nil
 }
 
 // NodeGetCapabilities implementation

--- a/csi/server/plugin/opensds/node_test.go
+++ b/csi/server/plugin/opensds/node_test.go
@@ -23,6 +23,16 @@ import (
 	"golang.org/x/net/context"
 )
 
+// NodeGetInfo for FakePlugin
+func (p *FakePlugin) NodeGetInfo(
+	ctx context.Context,
+	req *csi.NodeGetInfoRequest) (
+	*csi.NodeGetInfoResponse, error) {
+	return &csi.NodeGetInfoResponse{
+		NodeId: FakeIQN,
+	}, nil
+}
+
 func TestNodeGetId(t *testing.T) {
 	var fakePlugin = &Plugin{}
 	var fakeCtx = context.Background()
@@ -40,7 +50,23 @@ func TestNodeGetId(t *testing.T) {
 	}
 
 	if rs.NodeId != expectedNodeId {
-		t.Errorf("expected: %s, actual: %s\n", rs.NodeId, expectedNodeId)
+		t.Errorf("expected: %s, actual: %s\n", expectedNodeId, rs.NodeId)
+	}
+}
+
+func TestNodeGetInfo(t *testing.T) {
+	var fakePlugin = &FakePlugin{}
+	var fakeCtx = context.Background()
+	fakeReq := &csi.NodeGetInfoRequest{}
+	expectedNodeId := FakeIQN
+
+	rs, err := fakePlugin.NodeGetInfo(fakeCtx, fakeReq)
+	if err != nil {
+		t.Errorf("failed to GetNodeInfo: %v\n", err)
+	}
+
+	if rs.NodeId != expectedNodeId {
+		t.Errorf("expected: %s, actual: %s\n", expectedNodeId, rs.NodeId)
 	}
 }
 

--- a/csi/server/plugin/opensds/plugin.go
+++ b/csi/server/plugin/opensds/plugin.go
@@ -15,10 +15,14 @@
 package opensds
 
 const (
-	//PluginName setting
+	// PluginName setting
 	PluginName = "csi-opensdsplugin"
+	FakeIQN    = "fakeIqn"
 )
 
 // Plugin define
 type Plugin struct {
+}
+
+type FakePlugin struct {
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
NodeGetInfo is a required node RPC. Kubelet depends on it to
register a CSI plugin. This PR implements NodeGetInfo.

Note: Change in csi/server/plugin/opensds/plugin.go is a result of `go fmt`.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #98

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Implements NodeGetInfo for CSI driver.
```
