### PR TITLE
Create Volume should support idempotency

### DIFF
--- a/csi/server/plugin/opensds/controller.go
+++ b/csi/server/plugin/opensds/controller.go
@@ -167,10 +167,10 @@ func (p *Plugin) CreateVolume(
 	if isExist {
 		if isCompatible {
 			v = findVolume
+		} else {
+			return nil, status.Error(codes.AlreadyExists,
+				"Volume already exists but is incompatible")
 		}
-
-		return nil, status.Error(codes.AlreadyExists,
-			"Volume already exists but is incompatible")
 	} else {
 		createVolume, err := Client.CreateVolume(volumebody)
 		if err != nil {


### PR DESCRIPTION
If a volume exists and is compatible with the volume request,
the plugin should return success. Currently in the code there is
logic to find an existing compatible volume, but it returns
an error saying it is not compatible. This PR fixes it.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
