### PR TITLE
Change driver-registrar registration path

### DIFF
--- a/csi/server/deploy/kubernetes/csi-nodeplugin-opensdsplugin.yaml
+++ b/csi/server/deploy/kubernetes/csi-nodeplugin-opensdsplugin.yaml
@@ -132,5 +132,5 @@ spec:
             type: DirectoryOrCreate
         - name: registration-dir
           hostPath:
-            path: /var/lib/kubelet/plugins
+            path: /var/lib/kubelet/plugins_registry
             type: Directory


### PR DESCRIPTION
This PR changes the driver-registrar registration path to the new one.
New path: /var/lib/kubelet/plugins_registry/
Old path: /var/lib/kubelet/plugins

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
