### PR TITLE
Fix error when registration-dir doesn't exist.

### DIFF
--- a/csi/server/deploy/kubernetes/csi-nodeplugin-opensdsplugin.yaml
+++ b/csi/server/deploy/kubernetes/csi-nodeplugin-opensdsplugin.yaml
@@ -133,4 +133,4 @@ spec:
         - name: registration-dir
           hostPath:
             path: /var/lib/kubelet/plugins_registry
-            type: Directory
+            type: DirectoryOrCreate


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix error when registration-dir doesn't exist.

Test environment:
- Kuberenetes version: v1.13.0-beta.1
- Etcd version: 3.2.25

