### PR TITLE
Use official v1.0.1 sidecar container images

### DIFF
--- a/csi/server/deploy/kubernetes/csi-attacher-opensdsplugin.yaml
+++ b/csi/server/deploy/kubernetes/csi-attacher-opensdsplugin.yaml
@@ -33,8 +33,7 @@ spec:
       serviceAccount: csi-attacher
       containers:
         - name: csi-attacher
-          # TODO: replace with official image when available
-          image: xyang105/test-attacher:k8s1.13.0_beta.2 #quay.io/k8scsi/csi-attacher:v1.0.0
+          image: quay.io/k8scsi/csi-attacher:v1.0.1
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -47,6 +46,18 @@ spec:
               mountPath: /csi
             - name: iscsi-dir
               mountPath: /etc/iscsi/
+        - name: cluster-driver-registrar
+          image: quay.io/k8scsi/csi-cluster-driver-registrar:v1.0.1
+          args:
+            - "--v=5"
+            - "--pod-info-mount-version=\"v1\""
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
         - name: opensds
           image: opensdsio/csiplugin:latest
           args :

--- a/csi/server/deploy/kubernetes/csi-attacher-rbac.yaml
+++ b/csi/server/deploy/kubernetes/csi-attacher-rbac.yaml
@@ -27,6 +27,12 @@ rules:
   - apiGroups: ["csi.storage.k8s.io"]
     resources: ["csinodeinfos"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csidrivers"]
+    verbs: ["create", "delete", "get", "list", "watch"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["create","get", "list", "watch","delete"]
 
 ---
 kind: ClusterRoleBinding

--- a/csi/server/deploy/kubernetes/csi-nodeplugin-opensdsplugin.yaml
+++ b/csi/server/deploy/kubernetes/csi-nodeplugin-opensdsplugin.yaml
@@ -17,15 +17,11 @@ spec:
       serviceAccount: csi-nodeplugin
       hostNetwork: true
       containers:
-        - name: driver-registrar
-          # TODO: replace the following with official image when available
-          image: xyang105/test-registrar:release1.0 #quay.io/k8scsi/driver-registrar:v1.0-canary #v1.0.0
+        - name: node-driver-registrar
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.1
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"
-            - "--mode=node-register"
-            - "--driver-requires-attachment=true"
-            - "--pod-info-mount-version=v1"
             - "--kubelet-registration-path=$(ADDRESS)"
           env:
             - name: ADDRESS

--- a/csi/server/deploy/kubernetes/csi-provisioner-opensdsplugin.yaml
+++ b/csi/server/deploy/kubernetes/csi-provisioner-opensdsplugin.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccount: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.0.0
+          image: quay.io/k8scsi/csi-provisioner:v1.0.1
           args:
             - "--provisioner=csi-opensdsplugin"
             - "--csi-address=$(ADDRESS)"

--- a/csi/server/deploy/kubernetes/csi-snapshotter-opensdsplugin.yaml
+++ b/csi/server/deploy/kubernetes/csi-snapshotter-opensdsplugin.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccount: csi-snapshotter
       containers:
         - name: csi-snapshotter
-          image: quay.io/k8scsi/csi-snapshotter:v1.0.0
+          image: quay.io/k8scsi/csi-snapshotter:v1.0.1
           args:
             - "--snapshotter=csi-opensdsplugin"
             - "--csi-address=$(ADDRESS)"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR updates deployment yaml files to use official v1.0.1
sidecar container images.
driver-registrar is split into two sidecars: node-driver-regsitrar
and cluster-driver-registrar.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Tested with K8S v1.13.0. Enable CSINodeInfo and CSIDriverRegistry feature gates.

```
ALLOW_PRIVILEGED=true FEATURE_GATES=CSIPersistentVolume=true,MountPropagation=true,VolumeSnapshotDataSource=true,KubeletPluginsWatcher=true,CSINodeInfo=true,CSIDriverRegistry=true RUNTIME_CONFIG="storage.k8s.io/v1alpha1=true" LOG_LEVEL=5 hack/local-up-cluster.sh
```

Create CRD's as follows:
```
kubectl create -f https://raw.githubusercontent.com/kubernetes/csi-api/master/pkg/crd/manifests/csidriver.yaml --validate=false
kubectl create -f https://raw.githubusercontent.com/kubernetes/csi-api/master/pkg/crd/manifests/csinodeinfo.yaml --validate=false
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
