### PR TITLE
Added volume formatting type option and volume creation delay waiting.

### DIFF
--- a/csi/server/examples/kubernetes/nginx.yaml
+++ b/csi/server/examples/kubernetes/nginx.yaml
@@ -7,6 +7,7 @@ metadata:
   name: csi-sc-opensdsplugin
 provisioner: csi-opensdsplugin
 parameters:
+  fsytpe: ext4
 
 ---
 apiVersion: v1

--- a/csi/server/plugin/opensds/constants.go
+++ b/csi/server/plugin/opensds/constants.go
@@ -32,6 +32,7 @@ const (
 	KVolumeProfileId     = "profileId"
 	KVolumeLvPath        = "lvPath"
 	KVolumeReplicationId = "replicationId"
+	KVolumeFstype        = "fstype"
 )
 
 // CSI publish attribute keywords

--- a/csi/server/plugin/opensds/controller.go
+++ b/csi/server/plugin/opensds/controller.go
@@ -126,7 +126,7 @@ func (p *Plugin) CreateVolume(
 	var enableReplication = false
 	for k, v := range req.GetParameters() {
 		switch strings.ToLower(k) {
-		case "fstype":
+		case KVolumeFstype:
 			fstype = v
 		case KParamProfile:
 			volumebody.ProfileId = v
@@ -187,7 +187,7 @@ func (p *Plugin) CreateVolume(
 	} else {
 		createVolume, err := Client.CreateVolume(volumebody)
 		if err != nil {
-			glog.Error("failed to CreateVolume", err)
+			glog.Error("failed to CreateVolume: ", err)
 			return nil, err
 		} else {
 			v = createVolume

--- a/csi/server/plugin/opensds/controller_test.go
+++ b/csi/server/plugin/opensds/controller_test.go
@@ -137,6 +137,11 @@ func (*fakeVolumeReceiver) Recv(
 				return err
 			}
 			break
+		case *model.VolumeSpec:
+			if err := json.Unmarshal([]byte(ByteVolume), out); err != nil {
+				return err
+			}
+			break
 		default:
 			return errors.New("output format not supported")
 		}
@@ -435,9 +440,21 @@ func TestCreateVolume(t *testing.T) {
 	var fakeCtx = context.Background()
 	fakeReq := csi.CreateVolumeRequest{
 		Name: "sample-volume",
+		VolumeCapabilities: []*csi.VolumeCapability{
+			&csi.VolumeCapability{
+				AccessMode: &csi.VolumeCapability_AccessMode{
+					Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+				},
+				AccessType: &csi.VolumeCapability_Block{
+					Block: &csi.VolumeCapability_BlockVolume{},
+				},
+			},
+		},
+
 		Parameters: map[string]string{
 			"profile":          "1106b972-66ef-11e7-b172-db03f3689c9c",
 			"availabilityzone": "default",
+			"fstype":           "ext4",
 		},
 		VolumeContentSource: &csi.VolumeContentSource{
 			Type: &csi.VolumeContentSource_Snapshot{
@@ -463,6 +480,7 @@ func TestCreateVolume(t *testing.T) {
 			KVolumePoolId:    "084bf71e-a102-11e7-88a8-e31fe6d52248",
 			KVolumeProfileId: "1106b972-66ef-11e7-b172-db03f3689c9c",
 			KVolumeLvPath:    "",
+			KVolumeFstype:    "ext4",
 		},
 	}
 
@@ -476,12 +494,12 @@ func TestCreateVolume(t *testing.T) {
 }
 
 func TestIsStringMapEqual(t *testing.T) {
-	metadataA := map[string]string{"lvPath":"/dev/opensds-volumes-default/volume-105a8e15-8ab2-463c-9efb-7af1a3451138"}
-	metadataB := map[string]string{"lvPath":"/dev/opensds-volumes-default/volume-105a8e15-8ab2-463c-9efb-7af1a3451138"}
-	ret := isStringMapEqual(metadataA,metadataB)
-	
+	metadataA := map[string]string{"lvPath": "/dev/opensds-volumes-default/volume-105a8e15-8ab2-463c-9efb-7af1a3451138"}
+	metadataB := map[string]string{"lvPath": "/dev/opensds-volumes-default/volume-105a8e15-8ab2-463c-9efb-7af1a3451138"}
+	ret := isStringMapEqual(metadataA, metadataB)
+
 	if !ret {
 		t.Errorf("expected: true, actual: %v\n", ret)
 	}
-	
-	}
+
+}

--- a/csi/server/plugin/opensds/node_test.go
+++ b/csi/server/plugin/opensds/node_test.go
@@ -15,6 +15,7 @@
 package opensds
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -100,10 +101,12 @@ func TestNodeStageVolume(t *testing.T) {
 		},
 	}
 
-	fakeReq.PublishContext = map[string]string{KPublishAttachId: "f2dda3d2-bf79-11e7-8665-f750b088f63e"}
+	attachmentId := "f2dda3d2-bf79-11e7-8665-f750b088f63e"
+
+	fakeReq.PublishContext = map[string]string{KPublishAttachId: attachmentId}
 
 	_, err = fakePlugin.NodeStageVolume(fakeCtx, &fakeReq)
-	expectedErr = status.Error(codes.NotFound, "Volume does not exist")
+	expectedErr = status.Error(codes.FailedPrecondition, fmt.Sprintf("the volume attachment %s does not exist", attachmentId))
 
 	if !reflect.DeepEqual(expectedErr, err) {
 		t.Errorf("expected: %v, actual: %v\n", expectedErr, err)

--- a/csi/util/util.go
+++ b/csi/util/util.go
@@ -20,12 +20,14 @@ import (
 	"log"
 	"net"
 	"os"
+	"reflect"
 	"regexp"
 	"strings"
 	"time"
 
-	"google.golang.org/grpc"
 	"path"
+
+	"google.golang.org/grpc"
 )
 
 // getProtoandAdd return protocal and address
@@ -103,4 +105,35 @@ func GetCSIClientConn(csiEndpoint string) (*grpc.ClientConn, error) {
 
 	// Set up a connection to the server
 	return grpc.DialContext(ctx, target, dialOpts...)
+}
+
+// IsSupportFstype ...
+func IsSupportFstype(fstype string) bool {
+	supportFstypes := [...]string{"ext2", "ext3", "ext4", "cramfs", "minix"}
+	for _, v := range supportFstypes {
+		if strings.ToLower(fstype) == v {
+			return true
+		}
+	}
+	return false
+}
+
+// Contained ...
+func Contained(obj, target interface{}) bool {
+	targetValue := reflect.ValueOf(target)
+	switch reflect.TypeOf(target).Kind() {
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < targetValue.Len(); i++ {
+			if targetValue.Index(i).Interface() == obj {
+				return true
+			}
+		}
+	case reflect.Map:
+		if targetValue.MapIndex(reflect.ValueOf(obj)).IsValid() {
+			return true
+		}
+	default:
+		return false
+	}
+	return false
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. Added volume formatting type option to the  kubernetes configuration yaml file, so that user can choose volume formatted parameters, such as ext3, ext4.

2. Add the delay to wait for the deletion result due to asynchronously volume creation, the functions is `waitForVolStatusStable`.

3.Due to changes in many places, I can't do full testing with my single power, so the following scenarios need to be assisted in testing:
cindercompatiableapi
flexvolume
service-broker