### PR TITLE
Volume creation will fail if the storage type of profile is not block

### DIFF
--- a/csi/server/examples/kubernetes/nginx.yaml
+++ b/csi/server/examples/kubernetes/nginx.yaml
@@ -8,6 +8,8 @@ metadata:
 provisioner: csi-opensdsplugin
 parameters:
   attachMode: rw
+  profile: abc
+  storageType: block
 allowedTopologies:
 - matchLabelExpressions:
   - key: topology.csi-opensdsplugin/zone

--- a/csi/server/examples/kubernetes/pod-with-block-volume.yaml
+++ b/csi/server/examples/kubernetes/pod-with-block-volume.yaml
@@ -4,7 +4,8 @@ metadata:
   name: csi-sc-opensdsplugin-block
 provisioner: csi-opensdsplugin
 parameters:
-
+  profile: abc
+  storageType: block
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/csi/server/plugin/opensds/constants.go
+++ b/csi/server/plugin/opensds/constants.go
@@ -32,6 +32,7 @@ const (
 	KVolumeProfileId     = "profileId"
 	KVolumeLvPath        = "lvPath"
 	KVolumeReplicationId = "replicationId"
+	kStorageType         = "storagetype"
 )
 
 // CSI publish attribute keywords


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
When csi creates a volume without specifying a profile, the profile of the default is selected by default. But if the storageType of default profile is file the volume creation will fail. So
1.User must enter profile or volume creation will fail.
2.Determine if storageType of profile user inputs is file or block.
