### PR TITLE
IP address extraction fix for fileshare flow

### DIFF
--- a/csi/server/plugin/opensds/fileshare.go
+++ b/csi/server/plugin/opensds/fileshare.go
@@ -197,7 +197,8 @@ func (f *FileShare) ControllerPublishFileShare(req *csi.ControllerPublishVolumeR
 		attachMode = "read,write"
 	}
 
-	accessTo := strings.Split(req.GetNodeId(), ",")[IpIdx]
+	nodeInfo := strings.Split(req.GetNodeId(), ",")
+	accessTo := nodeInfo[len(nodeInfo)-1]
 	// check if fileshare exists
 	shareSpec, err := f.Client.GetFileShare(req.VolumeId)
 	if err != nil || shareSpec == nil {
@@ -292,7 +293,8 @@ func (f *FileShare) ControllerUnpublishFileShare(req *csi.ControllerUnpublishVol
 		return nil, status.Error(codes.FailedPrecondition, msg)
 	}
 
-	accessTo := strings.Split(req.GetNodeId(), ",")[IpIdx]
+	nodeInfo := strings.Split(req.GetNodeId(), ",")
+	accessTo := nodeInfo[len(nodeInfo)-1]
 
 	for _, attachSpec := range attachments {
 		if attachSpec.FileShareId == shareSpec.Id && attachSpec.AccessTo == accessTo {

--- a/csi/server/plugin/opensds/fileshare.go
+++ b/csi/server/plugin/opensds/fileshare.go
@@ -197,6 +197,7 @@ func (f *FileShare) ControllerPublishFileShare(req *csi.ControllerPublishVolumeR
 		attachMode = "read,write"
 	}
 
+	//NodeId is a comma seperated string consisting of hostname, iqn(iSCSI Qualified Name), nqn(NVMe Qualified Name), ip address in order
 	nodeInfo := strings.Split(req.GetNodeId(), ",")
 	accessTo := nodeInfo[len(nodeInfo)-1]
 	// check if fileshare exists
@@ -293,6 +294,7 @@ func (f *FileShare) ControllerUnpublishFileShare(req *csi.ControllerUnpublishVol
 		return nil, status.Error(codes.FailedPrecondition, msg)
 	}
 
+	//NodeId is a comma seperated string consisting of hostname, iqn(iSCSI Qualified Name), nqn(NVMe Qualified Name), ip address in order
 	nodeInfo := strings.Split(req.GetNodeId(), ",")
 	accessTo := nodeInfo[len(nodeInfo)-1]
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR addresses the issue of  not being able to create kubernetes application pod with fileshare.
Root cause was with the IP address extraction from node id for controller publish/unpublish fileshare flows. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Issue: https://github.com/opensds/nbp/issues/257

**Special notes for your reviewer**: NA
Test report attached below:
[test-report.docx](https://github.com/opensds/nbp/files/3750457/test-report.docx)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
