### PR TITLE
[Vmware/VRO] Remove encrypting password for Register Storage workflow backend.

### DIFF
--- a/vmware/vro/plugin/src/main/java/org/opensds/storage/vro/plugin/adapter/opensds/services/Configuration.java
+++ b/vmware/vro/plugin/src/main/java/org/opensds/storage/vro/plugin/adapter/opensds/services/Configuration.java
@@ -84,7 +84,7 @@ public class Configuration {
 		arrayInfo.setHostName(hostname);
 		arrayInfo.setPort(port);
 		arrayInfo.setUsername(username);
-		arrayInfo.setPassword(EncryptHelper.encrypt(password));
+		arrayInfo.setPassword(password);
 		arrayInfo.setauthEnabled(authEnabled);
 		arrayInfo.setProductModel(productModel);
 		if (LOG.isInfoEnabled()) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This is to Fix https://github.com/opensds/nbp/issues/311 .
Registering OpenSDS to VROoperation fails if OpenSDS has keystone auth startegy set.
VRO backend uses encrypted password but opensds need plain password.
**Which issue this PR fixes** 
 fixes #311 

**Special notes for your reviewer**:
NA
**Test Report**:
1. Registered OpenSDS for auth enabled and auth disabled setup.
2. Run other workflows which used the already registered opensds in inventory.
