### PR TITLE
Access capability fix for fileshare flow

### DIFF
--- a/csi/plugins/file/fileshare.go
+++ b/csi/plugins/file/fileshare.go
@@ -23,12 +23,16 @@ import (
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/golang/glog"
 	"github.com/opensds/nbp/csi/util"
+	nbputil "github.com/opensds/nbp/util"
 	"github.com/opensds/opensds/client"
-	nbputil "github.com/opensds/nbp/util"	
 	"github.com/opensds/opensds/contrib/connector"
 	"github.com/opensds/opensds/pkg/model"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+)
+
+const (
+	DefaultAttachMode = "Read,Write"
 )
 
 type FileShare struct {
@@ -46,7 +50,7 @@ func (f *FileShare) CreateFileShare(req *csi.CreateVolumeRequest) (*csi.CreateVo
 	// fileshare name
 	name = strings.Replace(req.GetName(), "-", "_", -1)
 
-	var attachMode = "read,write"
+	var attachMode = DefaultAttachMode
 	for k, v := range req.GetParameters() {
 		switch k {
 		case common.ParamProfile:
@@ -60,7 +64,7 @@ func (f *FileShare) CreateFileShare(req *csi.CreateVolumeRequest) (*csi.CreateVo
 		case common.PublishAttachMode:
 			if strings.ToLower(v) == "read" {
 				// attach mode
-				attachMode = "read"
+				attachMode = "Read"
 			} else {
 				glog.Infof("use default attach mode: %s", attachMode)
 			}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This is to fix the problem of pod creation using fileshare. 

Rootcause: CSI used to fill accessCapability field as "read" whereas fileshare acl is expecting values - Read, Write, execute and swagger validation was failing due to this mismatch

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Fixes the issue https://github.com/opensds/nbp/issues/316

**Special notes for your reviewer**:
Test cases executed :
1) Pod creation using file share - passed
2) Pod deletion using Fileshare  -  failed 
Failed due to hotpot issue (https://github.com/opensds/opensds/issues/1137)

One Gofmt issue also part of the commit

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
