### PR TITLE
[CSI] Remove alteration of fstab during volume mount/unmount

### DIFF
--- a/vendor/github.com/opensds/opensds/contrib/connector/common.go
+++ b/vendor/github.com/opensds/opensds/contrib/connector/common.go
@@ -111,13 +111,6 @@ func Mount(device, mountpoint, fsType string, mountFlags []string) error {
 		return err
 	}
 
-	// Make sure the mount is not lost after the host reboots
-	cmd := fmt.Sprintf("echo \"%s %s %s defaults 0 0\" >> /etc/fstab", device, mountpoint, fsType)
-	_, err = ExecCmd("/bin/bash", "-c", cmd)
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -131,11 +124,6 @@ func Umount(mountpoint string) error {
 		return err
 	}
 
-	cmd := fmt.Sprintf("cat -n /etc/fstab | grep -w '%s' | awk -F ' ' '{ print $1 }'| xargs -i sed -i '{}d' /etc/fstab", mountpoint)
-	_, err = ExecCmd("/bin/bash", "-c", cmd)
-	if err != nil {
-		return err
-	}
 	return nil
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This fix removes the /etc/fstab alteration during volume mount and unmount

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
This fix addresses the issue : https://github.com/opensds/nbp/issues/328

**Special notes for your reviewer**:
> Any other PR(s) this PR is dependant on: https://github.com/opensds/opensds/pull/1192

Test Steps:
> Create pod which uses pvc (volume mount will happen)
> Verify that /etc/fstab is not altered during the operation
> Delete pod
> Verify that /etc/fstab is not altered during the pod delete operation as well



**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
