### PR TITLE
[CSI] OFFLINE volume expansion support

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -37,12 +37,12 @@
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
-  digest = "1:94ffc0947c337d618b6ff5ed9abaddc1217b090c1b3a1ae4739b35b7b25851d5"
+  digest = "1:06e72a3140381f370345af6ed8986a22f4e6e7171fe317407c1d4675fe24e8d9"
   name = "github.com/container-storage-interface/spec"
   packages = ["lib/go/csi"]
   pruneopts = "NUT"
-  revision = "ed0bb0e1557548aa028307f48728767cfe8f6345"
-  version = "v1.0.0"
+  revision = "314ac542302938640c59b6fb501c635f27015326"
+  version = "v1.2.0"
 
 [[projects]]
   digest = "1:22db66c6af48fe0e93e971d796cad565ee9e0039646bd59bc8e29b7a7bd2d24e"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,7 +27,7 @@
 
 [[constraint]]
   name = "github.com/container-storage-interface/spec"
-  version = "1.0.0"
+  version = "1.2.0"
 
 [[override]]
   name = "github.com/golang/protobuf"

--- a/csi/cmd/block/Dockerfile
+++ b/csi/cmd/block/Dockerfile
@@ -10,7 +10,7 @@ COPY nvme-cli-1.8.1  /nvme-cli-1.8.1
 
 # Install iscsi
 RUN apt-get update && \
-    apt-get -y install open-iscsi \
+    apt-get -y install open-iscsi lsscsi\
     sysfsutils \
     sg3-utils \
     kmod \

--- a/csi/common/controller.go
+++ b/csi/common/controller.go
@@ -201,6 +201,13 @@ func ControllerGetCapabilities(
 					},
 				},
 			},
+			{
+				Type: &csi.ControllerServiceCapability_Rpc{
+					Rpc: &csi.ControllerServiceCapability_RPC{
+						Type: csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
+					},
+				},
+			},
 		},
 	}, nil
 }

--- a/csi/common/identity.go
+++ b/csi/common/identity.go
@@ -86,6 +86,13 @@ func GetPluginCapabilities(
 					},
 				},
 			},
+			{
+				Type: &csi.PluginCapability_VolumeExpansion_{
+					VolumeExpansion: &csi.PluginCapability_VolumeExpansion{
+						Type: csi.PluginCapability_VolumeExpansion_OFFLINE,
+					},
+				},
+			},
 		},
 	}, nil
 }

--- a/csi/common/node.go
+++ b/csi/common/node.go
@@ -206,6 +206,13 @@ func NodeGetCapabilities(
 					},
 				},
 			},
+			{
+				Type: &csi.NodeServiceCapability_Rpc{
+					Rpc: &csi.NodeServiceCapability_RPC{
+						Type: csi.NodeServiceCapability_RPC_EXPAND_VOLUME,
+					},
+				},
+			},
 		},
 	}, nil
 }

--- a/csi/deploy/kubernetes/block/csi-resizer-opensdsplugin.yaml
+++ b/csi/deploy/kubernetes/block/csi-resizer-opensdsplugin.yaml
@@ -1,0 +1,124 @@
+# This YAML file contains attacher & csi driver API objects,
+# which are necessary to run external csi resizer for opensds.
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: csi-resizer-opensdsplugin-block
+  labels:
+    app: csi-resizer-opensdsplugin-block
+spec:
+  selector:
+    app: csi-resizer-opensdsplugin-block
+  ports:
+    - name: dummy
+      port: 12345
+
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: csi-resizer-opensdsplugin-block
+spec:
+  serviceName: "csi-resizer-opensdsplugin-block"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-resizer-opensdsplugin-block
+  template:
+    metadata:
+      labels:
+        app: csi-resizer-opensdsplugin-block
+    spec:
+      serviceAccount: csi-resizer-block
+      containers:
+        - name: csi-resizer
+          image: quay.io/k8scsi/csi-resizer:v0.3.0
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--csiTimeout=15s"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: opensds
+          image: opensdsio/csiplugin-block:latest
+          args :
+            - "--csiEndpoint=$(CSI_ENDPOINT)"
+            - "--opensdsEndpoint=$(OPENSDS_ENDPOINT)"
+            - "--opensdsAuthStrategy=$(OPENSDS_AUTH_STRATEGY)"
+            - "--v=8"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix://csi/csi.sock
+            - name: OPENSDS_ENDPOINT
+              valueFrom:
+                configMapKeyRef:
+                  name: csi-configmap-opensdsplugin-block
+                  key: opensdsendpoint
+            - name: OPENSDS_AUTH_STRATEGY
+              valueFrom:
+                configMapKeyRef:
+                  name: csi-configmap-opensdsplugin-block
+                  key: opensdsauthstrategy
+            - name: OS_AUTH_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: csi-configmap-opensdsplugin-block
+                  key: osauthurl
+            - name: OS_USERNAME
+              valueFrom:
+                configMapKeyRef:
+                  name: csi-configmap-opensdsplugin-block
+                  key: osusername
+            - name: PASSWORD_ENCRYPTER
+              valueFrom:
+                configMapKeyRef:
+                  name: csi-configmap-opensdsplugin-block
+                  key: passwordencrypter
+            - name: OS_PASSWORD
+              valueFrom:
+                configMapKeyRef:
+                  name: csi-configmap-opensdsplugin-block
+                  key: ospassword
+            - name: PASSWORD_ENCRYPTER
+              valueFrom:
+                configMapKeyRef:
+                  name: csi-configmap-opensdsplugin-block
+                  key: passwordencrypter
+            - name: ENABLE_ENCRYPTED
+              valueFrom:
+                configMapKeyRef:
+                  name: csi-configmap-opensdsplugin-block
+                  key: enableEncrypted
+            - name: OS_TENANT_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: csi-configmap-opensdsplugin-block
+                  key: ostenantname
+            - name: OS_PROJECT_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: csi-configmap-opensdsplugin-block
+                  key: osprojectname
+            - name: OS_USER_DOMAIN_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: csi-configmap-opensdsplugin-block
+                  key: osuserdomainid
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+            - name: certificate-path
+              mountPath: /opt/opensds-security
+      volumes:
+        - name: socket-dir
+          emptyDir:
+        - name: certificate-path
+          hostPath:
+            path: /opt/opensds-security
+            type: DirectoryOrCreate

--- a/csi/deploy/kubernetes/block/csi-resizer-rbac.yaml
+++ b/csi/deploy/kubernetes/block/csi-resizer-rbac.yaml
@@ -1,0 +1,60 @@
+# This YAML file contains RBAC API objects,
+# which are necessary to run external csi resizer for opensds.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-resizer-block
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: external-resizer-runner-block
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses", "csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "create", "update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["create","get", "list", "watch","update", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots/status"]
+    verbs: ["update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create","get", "list", "watch","update", "delete"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-resizer-role-block
+subjects:
+  - kind: ServiceAccount
+    name: csi-resizer-block
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: external-resizer-runner-block
+  apiGroup: rbac.authorization.k8s.io

--- a/csi/examples/kubernetes/block/nginx.yaml
+++ b/csi/examples/kubernetes/block/nginx.yaml
@@ -9,6 +9,7 @@ provisioner: csi-opensdsplugin-block
 parameters:
   attachMode: rw
   profile: abc
+allowVolumeExpansion: true 
 allowedTopologies:
 - matchLabelExpressions:
   - key: topology.csi-opensdsplugin-block/zone
@@ -21,7 +22,7 @@ metadata:
   name: csi-pvc-opensdsplugin-block
 spec:
   accessModes:
-  - ReadWriteMany
+  - ReadWriteOnce
   resources:
     requests:
       storage: 1Gi

--- a/csi/plugins/block/controller.go
+++ b/csi/plugins/block/controller.go
@@ -98,6 +98,18 @@ func (p *Plugin) ControllerUnpublishVolume(
 	return p.VolumeClient.ControllerUnpublishVolume(req)
 }
 
+// ControllerExpandVolume implementation
+func (p *Plugin) ControllerExpandVolume(
+	ctx context.Context,
+	req *csi.ControllerExpandVolumeRequest) (
+	*csi.ControllerExpandVolumeResponse, error) {
+
+	glog.V(5).Infof("start to controller expand volume")
+	defer glog.V(5).Info("end to controller expand volume")
+
+	return p.VolumeClient.ExpandVolume(req)
+}
+
 // ValidateVolumeCapabilities implementation
 func (p *Plugin) ValidateVolumeCapabilities(
 	ctx context.Context,

--- a/csi/plugins/block/controller_test.go
+++ b/csi/plugins/block/controller_test.go
@@ -261,6 +261,13 @@ func TestControllerGetCapabilities(t *testing.T) {
 				},
 			},
 		},
+		&csi.ControllerServiceCapability{
+			Type: &csi.ControllerServiceCapability_Rpc{
+				Rpc: &csi.ControllerServiceCapability_RPC{
+					Type: csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
+				},
+			},
+		},		
 	}
 
 	rs, err := fakePlugin.ControllerGetCapabilities(fakeCtx, fakeReq)

--- a/csi/plugins/block/node.go
+++ b/csi/plugins/block/node.go
@@ -15,10 +15,17 @@
 package block
 
 import (
+	"fmt"
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/golang/glog"
 	"github.com/opensds/nbp/csi/common"
+	"github.com/opensds/nbp/csi/util"
+	"github.com/opensds/opensds/contrib/connector"
 	"golang.org/x/net/context"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"strings"
 )
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -104,6 +111,45 @@ func (p *Plugin) NodeUnpublishVolume(
 	return p.VolumeClient.NodeUnpublishVolume(req)
 }
 
+// NodeExpandVolume implementation
+func (p *Plugin) NodeExpandVolume(
+	ctx context.Context,
+	req *csi.NodeExpandVolumeRequest) (
+	*csi.NodeExpandVolumeResponse, error) {
+
+	glog.V(5).Info("start to node expand volume")
+
+	// Check REQUIRED field
+	defer glog.V(5).Info("end to node expand volume")
+	volumeID := req.GetVolumeId()
+	if len(volumeID) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "Volume ID not provided")
+	}
+
+	capacityBytes := common.GetSize(req.GetCapacityRange())
+	volSizeBytes := capacityBytes * util.GiB
+
+	args := []string{"-o", "source", "--noheadings", "--target", req.GetVolumePath()}
+	output, err := connector.ExecCmd("findmnt", args...)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "Could not determine device path: %v", err)
+	}
+
+	devicePath := strings.TrimSpace(string(output))
+	if len(devicePath) == 0 {
+		return nil, status.Errorf(codes.Internal, "Could not get valid device for mount path: %q", req.GetVolumePath())
+	}
+
+	if _, err := resize(devicePath, req.GetVolumePath()); err != nil {
+		return nil, status.Errorf(codes.Internal, "Could not resize volume %q (%q):  %v", volumeID, devicePath, err)
+	}
+
+	glog.V(5).Infof("Node expand volume completed for  volumeId: %v,  size: %v", volumeID, volSizeBytes)
+	return &csi.NodeExpandVolumeResponse{
+		CapacityBytes: volSizeBytes,
+	}, nil
+}
+
 // NodeGetInfo gets information on a node
 func (p *Plugin) NodeGetInfo(
 	ctx context.Context,
@@ -129,4 +175,89 @@ func (p *Plugin) NodeGetVolumeStats(
 	*csi.NodeGetVolumeStatsResponse, error) {
 
 	return common.NodeGetVolumeStats(ctx, req)
+}
+
+// Resize perform resize of file system
+func resize(devicePath string, deviceMountPath string) (bool, error) {
+	format, err := connector.GetFSType(devicePath)
+
+	if err != nil {
+		formatErr := fmt.Errorf("ResizeFS.Resize - error checking format for device %s: %v", devicePath, err)
+		return false, formatErr
+	}
+
+	// If disk has no format, there is no need to resize the disk because mkfs.*
+	// by default will use whole disk anyways.
+	if format == "" {
+		return false, nil
+	}
+
+	glog.V(5).Infof("File system type for the device: %v", format)
+	switch format {
+	case "ext3", "ext4":
+		return extResize(devicePath)
+	case "xfs":
+		return xfsResize(deviceMountPath)
+	}
+	return false, fmt.Errorf("Resize of format %s is not supported for device %s mounted at %s", format, devicePath, deviceMountPath)
+}
+
+func extResize(devicePath string) (bool, error) {
+
+	Para := fmt.Sprintf("lsscsi | grep %s", devicePath)
+	output, err := connector.ExecCmd("/bin/bash", "-c", Para)
+	if err != nil {
+		glog.V(5).Infof("Failed to execute lsscsi for device output : %v, err : %v", output, err)
+		glog.Error(err.Error())
+		return false, err
+	}
+
+	//Output looks like : [4:0:0:1]    disk    IET      VIRTUAL-DISK     0001  /dev/sdb
+	// Need to parse and get host identifier (4 in above case)
+	glog.V(5).Infof("end to node expand volume, lsscsi: %v", output)
+	hostId := strings.Split(output, " ")[0]
+	hostId = strings.Split(hostId, ":")[0]
+	hostId = strings.Split(hostId, "[")[1]
+
+	scanCommandPara := "'- - -' > /sys/class/scsi_host/host" + hostId + "/scan"
+
+	output, err = connector.ExecCmd("echo", scanCommandPara)
+	if err != nil {
+		glog.V(5).Infof("Failed to execute scan command for device output : %v, err : %v", output, err)
+		glog.Error(err.Error())
+		return false, err
+	}
+
+	deviceIndex := strings.Split(devicePath, "/dev/")[1]
+
+	reScanCommandPara := "'1' > /sys/block/" + deviceIndex + "/device/rescan"
+	output, err = connector.ExecCmd("echo", reScanCommandPara)
+	if err != nil {
+		glog.V(5).Infof("Failed to execute rescan command for device output : %v, err : %v", output, err)
+		glog.Error(err.Error())
+		return false, err
+	}
+
+	output, err = connector.ExecCmd("resize2fs", devicePath)
+	if err != nil {
+		glog.V(5).Infof("Failed to execute resize command for device path : %v", devicePath)
+		glog.Error(err.Error())
+		return false, err
+	}
+
+	glog.V(5).Infof("Resize success for device path : %v", devicePath)
+	return true, nil
+
+}
+
+func xfsResize(deviceMountPath string) (bool, error) {
+	args := []string{"-d", deviceMountPath}
+	output, err := connector.ExecCmd("xfs_growfs", args...)
+
+	if err == nil {
+		return true, nil
+	}
+
+	resizeError := fmt.Errorf("resize of device %s failed: %v. xfs_growfs output: %s", deviceMountPath, err, string(output))
+	return false, resizeError
 }

--- a/csi/plugins/block/node_test.go
+++ b/csi/plugins/block/node_test.go
@@ -67,6 +67,13 @@ func TestNodeGetCapabilities(t *testing.T) {
 				},
 			},
 		},
+		&csi.NodeServiceCapability{
+			Type: &csi.NodeServiceCapability_Rpc{
+				Rpc: &csi.NodeServiceCapability_RPC{
+					Type: csi.NodeServiceCapability_RPC_EXPAND_VOLUME,
+				},
+			},
+		},
 	}
 
 	rs, err := fakePlugin.NodeGetCapabilities(fakeCtx, fakeReq)

--- a/csi/plugins/file/controller.go
+++ b/csi/plugins/file/controller.go
@@ -19,6 +19,8 @@ import (
 	"github.com/golang/glog"
 	"github.com/opensds/nbp/csi/common"
 	"golang.org/x/net/context"
+        "google.golang.org/grpc/codes"
+        "google.golang.org/grpc/status"
 )
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -96,6 +98,17 @@ func (p *Plugin) ControllerUnpublishVolume(
 	}
 
 	return p.FileShareClient.ControllerUnpublishFileShare(req)
+}
+// ControllerExpandVolume implementation
+func (p *Plugin) ControllerExpandVolume(
+	ctx context.Context,
+	req *csi.ControllerExpandVolumeRequest) (
+	*csi.ControllerExpandVolumeResponse, error) {
+
+	glog.V(5).Infof("start to controller expand volume")
+	defer glog.V(5).Info("end to controller expand volume")
+
+	return nil, status.Error(codes.Unimplemented, "")
 }
 
 // ValidateVolumeCapabilities implementation

--- a/csi/plugins/file/node.go
+++ b/csi/plugins/file/node.go
@@ -19,6 +19,8 @@ import (
 	"github.com/golang/glog"
 	"github.com/opensds/nbp/csi/common"
 	"golang.org/x/net/context"
+        "google.golang.org/grpc/codes"
+        "google.golang.org/grpc/status"
 )
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -102,6 +104,18 @@ func (p *Plugin) NodeUnpublishVolume(
 	}
 
 	return p.FileShareClient.NodeUnpublishFileShare(req)
+}
+
+// NodeExpandVolume implementation
+func (p *Plugin) NodeExpandVolume(
+	ctx context.Context,
+	req *csi.NodeExpandVolumeRequest) (
+	*csi.NodeExpandVolumeResponse, error) {
+
+	glog.V(5).Info("start to node expand volume")
+
+	defer glog.V(5).Info("end to node expand volume")
+	return nil, status.Error(codes.Unimplemented, "")
 }
 
 // NodeGetInfo gets information on a node

--- a/vendor/github.com/opensds/opensds/contrib/connector/fc/linuxfc.go
+++ b/vendor/github.com/opensds/opensds/contrib/connector/fc/linuxfc.go
@@ -176,3 +176,28 @@ func trimDoubleQuotesInText(str string) string {
 	}
 	return str
 }
+
+func getMultipathDevice(deviceWWN string) (string, error) {
+	cmd := fmt.Sprintf("ls -l /dev/disk/by-id/ | grep %s", deviceWWN)
+	out, err := connector.ExecCmd("/bin/bash", "-c", cmd)
+	if err != nil {
+		msg := fmt.Sprintf("No DM of wwn %s exist", deviceWWN)
+		log.Println(msg)
+		return "", nil
+	}
+
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	for _, line := range lines {
+		splits := strings.Split(line, "../../")
+		if len(splits) == 2 {
+			name := splits[1]
+			if strings.HasPrefix(name, "dm") {
+				return fmt.Sprintf("/dev/%s", name), nil
+			}
+		}
+	}
+
+	msg := fmt.Sprintf("No DM of wwn %s exist", deviceWWN)
+	log.Println(msg)
+	return "", nil
+}

--- a/vendor/github.com/opensds/opensds/pkg/utils/pwd/pwd.go
+++ b/vendor/github.com/opensds/opensds/pkg/utils/pwd/pwd.go
@@ -14,10 +14,6 @@
 
 package pwd
 
-import (
-	"fmt"
-)
-
 type PwdEncrypter interface {
 	Encrypter(password string) (string, error)
 	Decrypter(code string) (string, error)
@@ -28,7 +24,6 @@ func NewPwdEncrypter(encrypter string) PwdEncrypter {
 	case "aes":
 		return NewAES()
 	default:
-		fmt.Println("Use default encryption tool: aes.")
 		return NewAES()
 	}
 }


### PR DESCRIPTION
What this PR does / why we need it:
This change addresses the offline volume expansion support from side

When the volume demand (pvc) is edited to request more volume csi containers will trigger csi block plugin to provision volume expansion.
Some key highlights

    Node and controller capabilities are extended to acknowledge offline volume support
    csi resizer sidecar container will be started during the deployment to receive expand volume related notification
    Controller Expand Volume expand function is added to trigger the volume expansion at opensds/backend side
    Node Expand Volume function is added to expand the filesystem already mounted on node

Which issue this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes #
This PR addresses part(offline) of the issue: #209

Special notes for your reviewer:

    Any other PR(s) this PR is dependant on: opensds/opensds#1174

Test steps:

    Create a pod which uses pvc of size x gb
    Delete just the pod where pvc is still there
    Edit the pvc with size more than initial size
    Create the pod again with the same pvc
    Verify that pv/pvc/opensds volumes all are expanded
    Verify that the volume mounted on node has expanded size

Release note: